### PR TITLE
Remove DKG, update to polkadot v1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 /Cargo.lock
+.vscode
 
 target
 .env

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,75 +85,75 @@ tree_hash = { version = "0.5.0", features = ["arbitrary"], default-features = fa
 ethereum_hashing = { version = "1.0.0-beta.2", default-features = false }
 ethereum_ssz = { version = "0.5.0", features = ["arbitrary"], default-features = false }
 
-sc-cli = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sc-offchain = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sc-executor = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sc-network = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sc-service = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sc-keystore = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sc-consensus-aura = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-consensus-aura = { default-features = false, version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-consensus = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sc-consensus = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sc-consensus-grandpa = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-consensus-grandpa = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-inherents = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-frame-system = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-staking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-grandpa = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-indices = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-session = { version = "4.0.0-dev", features = ["historical"], default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-staking-reward-curve = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-sudo = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-utility = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-block-builder = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-offchain = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-staking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-transaction-pool = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-version = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-frame-executive = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-frame-try-runtime = { version = "0.10.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+sc-cli = { version = "0.10.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sc-offchain = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sp-core = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sc-executor = { version = "0.10.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sc-network = { version = "0.10.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sc-service = { version = "0.10.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sc-keystore = { version = "4.0.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sc-consensus-aura = { version = "0.10.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sp-consensus-aura = { default-features = false, version = "0.10.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sp-consensus = { version = "0.10.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sc-consensus = { version = "0.10.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sc-consensus-grandpa = { version = "0.10.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sp-consensus-grandpa = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sp-runtime = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sp-io = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sp-inherents = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sp-keyring = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sp-std = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+frame-system = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+frame-support = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+pallet-staking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+pallet-balances = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+pallet-grandpa = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+pallet-indices = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+pallet-session = { version = "4.0.0-dev", features = ["historical"], default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+pallet-staking-reward-curve = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+pallet-sudo = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+pallet-utility = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sp-block-builder = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sp-offchain = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sp-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sp-staking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sp-transaction-pool = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sp-version = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+frame-executive = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+frame-try-runtime = { version = "0.10.0-dev", default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 
-pallet-aura = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-bags-list = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-frame-election-provider-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-election-provider-multi-phase = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+pallet-aura = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+pallet-bags-list = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+frame-election-provider-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+pallet-election-provider-multi-phase = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 
 # These dependencies are used for the node template's RPCs
 jsonrpsee = { version = "0.16.2", default-features = false }
-sc-rpc = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0", default-features = false }
-sc-rpc-api = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sc-basic-authorship = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-substrate-frame-rpc-system = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-transaction-payment-rpc = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+sc-rpc = { version = "4.0.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
+sc-rpc-api = { version = "0.10.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+sc-basic-authorship = { version = "0.10.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+substrate-frame-rpc-system = { version = "4.0.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+pallet-transaction-payment-rpc = { version = "4.0.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 
 # Used for the node template's RPCs
-frame-system-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+frame-system-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 
 
 # These dependencies are used for runtime benchmarking
-frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-try-runtime-cli = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+try-runtime-cli = { version = "0.10.0-dev", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 
 # local deps
 pallet-eth2-light-client = { path = "./pallets/eth2-light-client", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2021"
 
 [workspace]
 members = [
-    "pallets/*",
+    "pallets/eth2-light-client",
+    "pallets/light-verifier",
     "crates/*",
     "eth2substrate-block-relay-rs",
     "gadget",
@@ -76,7 +77,7 @@ webb = { version = "0.7.3", default-features = false, features = [
     "evm-runtime",
     "substrate-runtime",
 ]}
-webb-proposals = { git = "https://github.com/webb-tools/webb-rs.git", rev="a960eaf", default-features = false, features = ["scale", "evm"] }
+webb-proposals = { git = "https://github.com/webb-tools/webb-rs.git", default-features = false, features = ["scale", "evm"] }
 
 milagro_bls = { git = "https://github.com/Snowfork/milagro_bls", default-features = false, rev="a6d66e4eb89015e352fb1c9f7b661ecdbb5b2176" }
 types = { git = "https://github.com/webb-tools/lighthouse.git", rev="ef72e752eaf45f4b7eb64dd8dbb0fe088f955df8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,9 +81,9 @@ webb-proposals = { git = "https://github.com/webb-tools/webb-rs.git", rev="a960e
 milagro_bls = { git = "https://github.com/Snowfork/milagro_bls", default-features = false, rev="a6d66e4eb89015e352fb1c9f7b661ecdbb5b2176" }
 types = { git = "https://github.com/webb-tools/lighthouse.git", rev="ef72e752eaf45f4b7eb64dd8dbb0fe088f955df8" }
 merkle_proof = { git = "https://github.com/webb-tools/lighthouse.git", rev="ef72e752eaf45f4b7eb64dd8dbb0fe088f955df8" }
-tree_hash = { version = "0.5.0", features = ["arbitrary"] }
-ethereum_hashing = { version = "1.0.0-beta.2" }
-ethereum_ssz = { version = "0.5.0", features = ["arbitrary"] }
+tree_hash = { version = "0.5.0", features = ["arbitrary"], default-features = false }
+ethereum_hashing = { version = "1.0.0-beta.2", default-features = false }
+ethereum_ssz = { version = "0.5.0", features = ["arbitrary"], default-features = false }
 
 
 # DKG Substrate Dependencies
@@ -164,4 +164,4 @@ frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, g
 try-runtime-cli = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 
 # local deps
-webb-light-client-primitives = { path = "./primitives" }
+webb-light-client-primitives = { path = "./primitives", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ webb = { version = "0.7.3", default-features = false, features = [
     "evm-runtime",
     "substrate-runtime",
 ]}
-webb-proposals = { git = "https://github.com/webb-tools/webb-rs.git", default-features = false, features = ["scale", "evm"] }
+webb-proposals = { git = "https://github.com/webb-tools/webb-rs", default-features = false, features = ["scale", "evm"] }
 
 milagro_bls = { git = "https://github.com/Snowfork/milagro_bls", default-features = false, rev="a6d66e4eb89015e352fb1c9f7b661ecdbb5b2176" }
 types = { git = "https://github.com/webb-tools/lighthouse.git", rev="ef72e752eaf45f4b7eb64dd8dbb0fe088f955df8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,14 +85,6 @@ tree_hash = { version = "0.5.0", features = ["arbitrary"], default-features = fa
 ethereum_hashing = { version = "1.0.0-beta.2", default-features = false }
 ethereum_ssz = { version = "0.5.0", features = ["arbitrary"], default-features = false }
 
-
-# DKG Substrate Dependencies
-dkg-runtime-primitives = { git = "https://github.com/webb-tools/dkg-substrate.git", branch = "master", default-features = false }
-pallet-dkg-metadata = { git = "https://github.com/webb-tools/dkg-substrate.git", branch = "master", default-features = false }
-pallet-dkg-proposal-handler = { git = "https://github.com/webb-tools/dkg-substrate.git", branch = "master", default-features = false }
-pallet-dkg-proposals = { git = "https://github.com/webb-tools/dkg-substrate.git", branch = "master", default-features = false }
-pallet-bridge-registry = { git = "https://github.com/webb-tools/dkg-substrate.git", branch = "master", default-features = false }
-
 sc-cli = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 sc-offchain = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
@@ -164,4 +156,5 @@ frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, g
 try-runtime-cli = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 
 # local deps
+pallet-eth2-light-client = { path = "./pallets/eth2-light-client", default-features = false }
 webb-light-client-primitives = { path = "./primitives", default-features = false }

--- a/crates/consensus-types/Cargo.toml
+++ b/crates/consensus-types/Cargo.toml
@@ -16,7 +16,7 @@ eth2-serde-utils = { package = "webb-eth2-serde-utils", path = "../serde-utils",
 
 bitvec = { workspace = true, features = ["atomic", "alloc"] }
 hex = { workspace = true }
-codec = { package = "parity-scale-codec", workspace = true }
+codec = { workspace = true }
 scale-info = { workspace = true }
 serde = { workspace = true }
 rlp = { workspace = true }

--- a/crates/eth-types/Cargo.toml
+++ b/crates/eth-types/Cargo.toml
@@ -12,7 +12,7 @@ tree-hash = { package = "webb-tree-hash",  path = "../tree-hash", default-featur
 tree-hash-derive = { package = "webb-tree-hash-derive", path = "../tree-hash-derive", default-features = false }
 eth2-serde-utils = { package = "webb-eth2-serde-utils", path = "../serde-utils", default-features = false, optional = true }
 hex = { workspace = true }
-codec = { package = "parity-scale-codec", workspace = true }
+codec = { workspace = true }
 scale-info = { workspace = true }
 serde = { workspace = true }
 rlp = { workspace = true }

--- a/crates/eth2-hashing/Cargo.toml
+++ b/crates/eth2-hashing/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Paul Hauner <paul@paulhauner.com>, Webb Developers <hello@webb.tools
 description = "Hashing primitives used in Ethereum 2.0"
 
 [dependencies]
-lazy_static = { workspace = true, optional = true,features = ["spin_no_std"] }
+lazy_static = { workspace = true, optional = true, features = ["spin_no_std"] }
 ring = { workspace = true, optional = true }
 sha2 = { workspace = true }
 

--- a/gadget/Cargo.toml
+++ b/gadget/Cargo.toml
@@ -20,4 +20,4 @@ eth2-pallet-init = { package = "webb-eth2-pallet-init", path = "../crates/eth2-p
 lc-relayer-context = { package = "webb-lc-relayer-context", path = "../crates/lc-relayer-context" }
 lc-relay-config = { package = "webb-lc-relay-config", path = "../crates/lc-relay-config" }
 # Webb
-webb-proposals = { workspace = true, features = ["scale", "evm"] }
+webb-proposals = { workspace = true, features = ["scale", "evm"], default-features = true }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -72,7 +72,7 @@ frame-benchmarking-cli = { workspace = true }
 try-runtime-cli = { workspace = true, optional = true }
 
 [build-dependencies]
-substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 
 [features]
 default = []

--- a/node/src/benchmarking.rs
+++ b/node/src/benchmarking.rs
@@ -82,11 +82,8 @@ impl frame_benchmarking_cli::ExtrinsicBuilder for TransferKeepAliveBuilder {
 		let extrinsic: OpaqueExtrinsic = create_benchmark_extrinsic(
 			self.client.as_ref(),
 			acc,
-			BalancesCall::transfer_keep_alive {
-				dest: self.dest.clone().into(),
-				value: self.value.into(),
-			}
-			.into(),
+			BalancesCall::transfer_keep_alive { dest: self.dest.clone().into(), value: self.value }
+				.into(),
 			nonce,
 		)
 		.into();

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,7 +1,19 @@
 use node_template_runtime::{
-	opaque::SessionKeys, AccountId, Balance, BalancesConfig, DKGConfig, DKGId, Eth2ClientConfig,
-	IndicesConfig, MaxNominations, RuntimeGenesisConfig, SessionConfig, Signature, StakingConfig,
-	SudoConfig, SystemConfig, DOLLARS, WASM_BINARY,
+	opaque::SessionKeys,
+	AccountId,
+	Balance,
+	BalancesConfig,
+	// Eth2ClientConfig,
+	IndicesConfig,
+	MaxNominations,
+	RuntimeGenesisConfig,
+	SessionConfig,
+	Signature,
+	StakingConfig,
+	SudoConfig,
+	SystemConfig,
+	DOLLARS,
+	WASM_BINARY,
 };
 use pallet_staking::StakerStatus;
 use sc_service::ChainType;
@@ -39,18 +51,17 @@ where
 }
 
 /// Helper function to generate stash, controller and session key from seed
-pub fn authority_keys_from_seed(seed: &str) -> (AccountId, AccountId, GrandpaId, AuraId, DKGId) {
+pub fn authority_keys_from_seed(seed: &str) -> (AccountId, AccountId, GrandpaId, AuraId) {
 	(
 		get_account_id_from_seed::<sr25519::Public>(&format!("{}//stash", seed)),
 		get_account_id_from_seed::<sr25519::Public>(seed),
 		get_from_seed::<GrandpaId>(seed),
 		get_from_seed::<AuraId>(seed),
-		get_from_seed::<DKGId>(seed),
 	)
 }
 
-fn session_keys(grandpa: GrandpaId, aura: AuraId, dkg: DKGId) -> SessionKeys {
-	SessionKeys { grandpa, aura, dkg }
+fn session_keys(grandpa: GrandpaId, aura: AuraId) -> SessionKeys {
+	SessionKeys { grandpa, aura }
 }
 
 fn development_config_genesis() -> RuntimeGenesisConfig {
@@ -110,7 +121,7 @@ pub fn local_testnet_config() -> ChainSpec {
 /// Configure initial storage state for FRAME modules.
 fn testnet_genesis(
 	wasm_binary: &[u8],
-	initial_authorities: Vec<(AccountId, AccountId, GrandpaId, AuraId, DKGId)>,
+	initial_authorities: Vec<(AccountId, AccountId, GrandpaId, AuraId)>,
 	initial_nominators: Vec<AccountId>,
 	root_key: AccountId,
 	endowed_accounts: Option<Vec<AccountId>>,
@@ -177,9 +188,7 @@ fn testnet_genesis(
 		session: SessionConfig {
 			keys: initial_authorities
 				.iter()
-				.map(|x| {
-					(x.0.clone(), x.0.clone(), session_keys(x.2.clone(), x.3.clone(), x.4.clone()))
-				})
+				.map(|x| (x.0.clone(), x.0.clone(), session_keys(x.2.clone(), x.3.clone())))
 				.collect::<Vec<_>>(),
 		},
 		staking: StakingConfig {
@@ -197,12 +206,12 @@ fn testnet_genesis(
 			key: Some(root_key),
 		},
 		transaction_payment: Default::default(),
-		eth_2_client: Eth2ClientConfig {
-			networks: vec![
-				(TypedChainId::Evm(1), NetworkConfig::new(&Network::Mainnet)),
-				(TypedChainId::Evm(5), NetworkConfig::new(&Network::Goerli)),
-			],
-			phantom: std::marker::PhantomData,
-		},
+		// eth_2_client: Eth2ClientConfig {
+		// 	networks: vec![
+		// 		(TypedChainId::Evm(1), NetworkConfig::new(&Network::Mainnet)),
+		// 		(TypedChainId::Evm(5), NetworkConfig::new(&Network::Goerli)),
+		// 	],
+		// 	phantom: std::marker::PhantomData,
+		// },
 	}
 }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -204,12 +204,5 @@ fn testnet_genesis(
 			],
 			phantom: std::marker::PhantomData,
 		},
-		dkg: DKGConfig {
-			authorities: initial_authorities.iter().map(|(.., x)| x.clone()).collect::<_>(),
-			keygen_threshold: 2,
-			signature_threshold: 1,
-			authority_ids: initial_authorities.iter().map(|(x, ..)| x.clone()).collect::<_>(),
-		},
-		dkg_proposals: Default::default(),
 	}
 }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,19 +1,7 @@
 use node_template_runtime::{
-	opaque::SessionKeys,
-	AccountId,
-	Balance,
-	BalancesConfig,
-	Eth2ClientConfig,
-	IndicesConfig,
-	MaxNominations,
-	RuntimeGenesisConfig,
-	SessionConfig,
-	Signature,
-	StakingConfig,
-	SudoConfig,
-	SystemConfig,
-	DOLLARS,
-	WASM_BINARY,
+	opaque::SessionKeys, AccountId, Balance, BalancesConfig, Eth2ClientConfig, IndicesConfig,
+	MaxNominations, RuntimeGenesisConfig, SessionConfig, Signature, StakingConfig, SudoConfig,
+	SystemConfig, DOLLARS, WASM_BINARY,
 };
 use pallet_staking::StakerStatus;
 use sc_service::ChainType;

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -3,7 +3,7 @@ use node_template_runtime::{
 	AccountId,
 	Balance,
 	BalancesConfig,
-	// Eth2ClientConfig,
+	Eth2ClientConfig,
 	IndicesConfig,
 	MaxNominations,
 	RuntimeGenesisConfig,
@@ -165,7 +165,6 @@ fn testnet_genesis(
 			let nominations = initial_authorities
 				.as_slice()
 				.choose_multiple(&mut rng, count)
-				.into_iter()
 				.map(|choice| choice.0.clone())
 				.collect::<Vec<_>>();
 			(x.clone(), x.clone(), STASH, StakerStatus::Nominator(nominations))
@@ -206,12 +205,12 @@ fn testnet_genesis(
 			key: Some(root_key),
 		},
 		transaction_payment: Default::default(),
-		// eth_2_client: Eth2ClientConfig {
-		// 	networks: vec![
-		// 		(TypedChainId::Evm(1), NetworkConfig::new(&Network::Mainnet)),
-		// 		(TypedChainId::Evm(5), NetworkConfig::new(&Network::Goerli)),
-		// 	],
-		// 	phantom: std::marker::PhantomData,
-		// },
+		eth_2_client: Eth2ClientConfig {
+			networks: vec![
+				(TypedChainId::Evm(1), NetworkConfig::new(&Network::Mainnet)),
+				(TypedChainId::Evm(5), NetworkConfig::new(&Network::Goerli)),
+			],
+			phantom: std::marker::PhantomData,
+		},
 	}
 }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -10,7 +10,7 @@ use sc_service::{error::Error as ServiceError, Configuration, TaskManager, WarpS
 use sc_telemetry::{Telemetry, TelemetryWorker};
 use sc_transaction_pool_api::OffchainTransactionPoolFactory;
 use sp_consensus_aura::sr25519::AuthorityPair as AuraPair;
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 use webb_proposals::TypedChainId;
 
 /// The minimum period of blocks on which justifications will be
@@ -290,33 +290,17 @@ pub fn new_full(
 			.spawn_blocking("aura", Some("block-authoring"), aura);
 
 		// Start Eth2 Light client Relayer Gadget - (MAINNET RELAYER)
-		// task_manager.spawn_handle().spawn(
-		// 	"mainnet-relayer-gadget",
-		// 	None,
-		// 	pallet_eth2_light_client_relayer_gadget::start_gadget(
-		// 		pallet_eth2_light_client_relayer_gadget::Eth2LightClientParams {
-		// 			lc_relay_config_path: relayer_cmd.light_client_relay_config_path.clone(),
-		// 			lc_init_config_path: relayer_cmd.light_client_init_pallet_config_path.clone(),
-		// 			eth2_chain_id: TypedChainId::Evm(1),
-		// 		},
-		// 	),
-		// );
-
-		// // Start Eth2 Light client Relayer Gadget - (GOERLI TESTNET RELAYER)
-		// task_manager.spawn_handle().spawn(
-		// 	"goerli-relayer-gadget",
-		// 	None,
-		// 	pallet_eth2_light_client_relayer_gadget::start_gadget(
-		// 		pallet_eth2_light_client_relayer_gadget::Eth2LightClientParams {
-		// 			local_keystore: keystore_container.local_keystore(),
-		// 			ew_config_dir: relayer_cmd.relayer_config_dir,
-		// 			lc_config_path: relayer_cmd.light_client_config_path,
-		// 			database_path,
-		// 			rpc_addr,
-		// 			eth2_chain_id: TypedChainId::Evm(5),
-		// 		},
-		// 	),
-		// );
+		task_manager.spawn_handle().spawn(
+			"mainnet-relayer-gadget",
+			None,
+			pallet_eth2_light_client_relayer_gadget::start_gadget(
+				pallet_eth2_light_client_relayer_gadget::Eth2LightClientParams {
+					lc_relay_config_path: relayer_cmd.light_client_relay_config_path.clone(),
+					lc_init_config_path: relayer_cmd.light_client_init_pallet_config_path.clone(),
+					eth2_chain_id: TypedChainId::Evm(1),
+				},
+			),
+		);
 	}
 
 	if enable_grandpa {

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -13,6 +13,10 @@ use sp_consensus_aura::sr25519::AuthorityPair as AuraPair;
 use std::{sync::Arc, time::Duration};
 use webb_proposals::TypedChainId;
 
+/// The minimum period of blocks on which justifications will be
+/// imported and generated.
+const GRANDPA_JUSTIFICATION_PERIOD: u32 = 512;
+
 // Our native executor instance.
 pub struct ExecutorDispatch;
 
@@ -45,7 +49,7 @@ pub fn new_partial(
 		FullClient,
 		FullBackend,
 		FullSelectChain,
-		sc_consensus::DefaultImportQueue<Block, FullClient>,
+		sc_consensus::DefaultImportQueue<Block>,
 		sc_transaction_pool::FullPool<Block, FullClient>,
 		(
 			sc_consensus_grandpa::GrandpaBlockImport<
@@ -71,7 +75,7 @@ pub fn new_partial(
 		})
 		.transpose()?;
 
-	let executor = sc_service::new_native_or_wasm_executor(&config);
+	let executor = sc_service::new_native_or_wasm_executor(config);
 	let (client, backend, keystore_container, task_manager) =
 		sc_service::new_full_parts::<Block, RuntimeApi, _>(
 			config,
@@ -97,7 +101,8 @@ pub fn new_partial(
 
 	let (grandpa_block_import, grandpa_link) = sc_consensus_grandpa::block_import(
 		client.clone(),
-		&(client.clone() as Arc<_>),
+		GRANDPA_JUSTIFICATION_PERIOD,
+		&client,
 		select_chain.clone(),
 		telemetry.as_ref().map(|x| x.handle()),
 	)?;
@@ -285,17 +290,17 @@ pub fn new_full(
 			.spawn_blocking("aura", Some("block-authoring"), aura);
 
 		// Start Eth2 Light client Relayer Gadget - (MAINNET RELAYER)
-		task_manager.spawn_handle().spawn(
-			"mainnet-relayer-gadget",
-			None,
-			pallet_eth2_light_client_relayer_gadget::start_gadget(
-				pallet_eth2_light_client_relayer_gadget::Eth2LightClientParams {
-					lc_relay_config_path: relayer_cmd.light_client_relay_config_path.clone(),
-					lc_init_config_path: relayer_cmd.light_client_init_pallet_config_path.clone(),
-					eth2_chain_id: TypedChainId::Evm(1),
-				},
-			),
-		);
+		// task_manager.spawn_handle().spawn(
+		// 	"mainnet-relayer-gadget",
+		// 	None,
+		// 	pallet_eth2_light_client_relayer_gadget::start_gadget(
+		// 		pallet_eth2_light_client_relayer_gadget::Eth2LightClientParams {
+		// 			lc_relay_config_path: relayer_cmd.light_client_relay_config_path.clone(),
+		// 			lc_init_config_path: relayer_cmd.light_client_init_pallet_config_path.clone(),
+		// 			eth2_chain_id: TypedChainId::Evm(1),
+		// 		},
+		// 	),
+		// );
 
 		// // Start Eth2 Light client Relayer Gadget - (GOERLI TESTNET RELAYER)
 		// task_manager.spawn_handle().spawn(
@@ -320,13 +325,12 @@ pub fn new_full(
 		let keystore = if role.is_authority() { Some(keystore_container.keystore()) } else { None };
 
 		let grandpa_config = sc_consensus_grandpa::Config {
-			// FIXME #1578 make this available through chainspec
-			gossip_duration: Duration::from_millis(333),
-			justification_period: 512,
+			gossip_duration: std::time::Duration::from_millis(333),
+			justification_generation_period: GRANDPA_JUSTIFICATION_PERIOD,
 			name: Some(name),
 			observer_enabled: false,
 			keystore,
-			local_role: role,
+			local_role: role.clone(),
 			telemetry: telemetry.as_ref().map(|x| x.handle()),
 			protocol_name: grandpa_protocol_name,
 		};

--- a/pallets/eth2-light-client/Cargo.toml
+++ b/pallets/eth2-light-client/Cargo.toml
@@ -18,6 +18,7 @@ consensus = { package = "webb-consensus-types", path = "../../crates/consensus-t
 frame-support = { workspace = true, default-features = false }
 frame-system = { workspace = true }
 pallet-balances = { workspace = true }
+sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 sp-core = { workspace = true }
@@ -54,6 +55,7 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"pallet-balances/std",
+	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",
 	"sp-core/std",

--- a/pallets/eth2-light-client/Cargo.toml
+++ b/pallets/eth2-light-client/Cargo.toml
@@ -25,7 +25,7 @@ sp-core = { workspace = true }
 
 log = { workspace = true }
 serde = { workspace = true, optional = true }
-codec = { package = "parity-scale-codec",workspace = true, features = ["derive", "max-encoded-len"] }
+codec = { workspace = true, features = ["derive", "max-encoded-len"] }
 scale-info = { workspace = true }
 webb-proposals = { workspace = true, features = ["evm", "substrate"] }
 ethereum-types =  { workspace = true }

--- a/pallets/eth2-light-client/Cargo.toml
+++ b/pallets/eth2-light-client/Cargo.toml
@@ -68,13 +68,12 @@ std = [
 	"eth2-ssz/std",
 	"tree-hash/std",
 	"merkle-proof/std",
-	"async-trait"
+	"async-trait",
+	"eth2-pallet-init",
 	
 ]
 testing = [
 	"std",
-	"eth2-pallet-init",
-	"async-trait",
 ]
 
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/eth2-light-client/Cargo.toml
+++ b/pallets/eth2-light-client/Cargo.toml
@@ -68,6 +68,7 @@ std = [
 	"eth2-ssz/std",
 	"tree-hash/std",
 	"merkle-proof/std",
+	"async-trait"
 	
 ]
 testing = [

--- a/pallets/eth2-light-client/Cargo.toml
+++ b/pallets/eth2-light-client/Cargo.toml
@@ -27,7 +27,7 @@ log = { workspace = true }
 serde = { workspace = true, optional = true }
 codec = { package = "parity-scale-codec",workspace = true, features = ["derive", "max-encoded-len"] }
 scale-info = { workspace = true }
-webb-proposals = { workspace = true, features = ["scale", "evm", "substrate"] }
+webb-proposals = { workspace = true, features = ["evm", "substrate"] }
 ethereum-types =  { workspace = true }
 derive_more =  { workspace = true }
 rlp =  { workspace = true }
@@ -39,8 +39,8 @@ webb-light-client-primitives = { workspace = true }
 anyhow = { workspace = true }
 lazy_static = { workspace = true }
 serde_json = { workspace = true }
-eth2-pallet-init = { package = "webb-eth2-pallet-init", path = "../../crates/eth2-pallet-init" }
-async-trait = { workspace = true }
+eth2-pallet-init = { package = "webb-eth2-pallet-init", optional = true, path = "../../crates/eth2-pallet-init" }
+async-trait = { workspace = true, optional = true }
 
 [features]
 default = ["std"]
@@ -72,6 +72,8 @@ std = [
 ]
 testing = [
 	"std",
+	"eth2-pallet-init",
+	"async-trait",
 ]
 
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/eth2-light-client/runtime-api/Cargo.toml
+++ b/pallets/eth2-light-client/runtime-api/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", workspace = true }
+codec = { workspace = true }
 sp-api = { workspace = true }
 webb-proposals = { workspace = true }
 eth-types = { path = "../../../crates/eth-types", default-features = false }

--- a/pallets/eth2-light-client/src/lib.rs
+++ b/pallets/eth2-light-client/src/lib.rs
@@ -529,7 +529,7 @@ pub mod pallet {
 				let unfinalized_head_execution_header =
 					UnfinalizedHeadExecutionHeader::<T>::get(typed_chain_id)
 						.ok_or(Error::<T>::UnfinalizedHeaderNotPresent)?;
-				frame_support::log::debug!(
+				log::debug!(
 					target: "light-client",
 					"Current finalized block number: {:?}, New finalized block number: {:?}",
 					finalized_execution_header.block_number,
@@ -559,7 +559,7 @@ pub mod pallet {
 				UnfinalizedTailExecutionHeader::<T>::insert(typed_chain_id, block_info);
 			}
 
-			frame_support::log::debug!(
+			log::debug!(
 				target: "light-client",
 				"Submitted header number {:?}, hash {:#?}",
 				block_header.number, block_hash
@@ -936,7 +936,7 @@ impl<T: Config> Pallet<T> {
 			NextSyncCommittee::<T>::insert(typed_chain_id, next_sync_committee);
 		}
 
-		frame_support::log::debug!(
+		log::debug!(
 			target: "light-client",
 			"Current finalized slot: {:?}, New finalized slot: {:?}",
 			finalized_beacon_header.header.slot,

--- a/pallets/eth2-light-client/src/mock.rs
+++ b/pallets/eth2-light-client/src/mock.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate as pallet_eth2_light_client;
 
 use consensus::network_config::{Network, NetworkConfig};
-use frame_support::{parameter_types, sp_io};
+use frame_support::parameter_types;
 use frame_system as system;
 use sp_core::H256;
 use sp_runtime::{

--- a/pallets/eth2-light-client/src/tests.rs
+++ b/pallets/eth2-light-client/src/tests.rs
@@ -1,11 +1,8 @@
-use crate::{mock::*, test_utils::*, Error, Lsb0, Paused};
-use bitvec::bitarr;
-use consensus::{EPOCHS_PER_SYNC_COMMITTEE_PERIOD, SLOTS_PER_EPOCH};
-use eth_types::{eth2::LightClientUpdate, pallet::InitInput, BlockHeader, U256};
+use crate::{mock::*, test_utils::*};
+
+use eth_types::{eth2::LightClientUpdate, pallet::InitInput, BlockHeader};
 use frame_support::assert_ok;
 
-use eth_types::H256;
-use frame_support::assert_err;
 use sp_runtime::AccountId32;
 
 use webb_proposals::TypedChainId;
@@ -47,9 +44,7 @@ pub fn get_test_context(
 }
 
 mod generic_tests {
-	use super::*;
-	use hex::FromHex;
-	use tree_hash::TreeHash;
+
 	#[test]
 	pub fn test_header_root() {
 		let header =
@@ -482,7 +477,7 @@ mod generic_tests {
 }
 
 mod mainnet_tests {
-	use super::*;
+
 	#[test]
 	pub fn test_panic_on_init_in_trustless_mode_without_bls_on_mainnet() {
 		new_test_ext().execute_with(|| {

--- a/pallets/eth2-light-client/src/tests.rs
+++ b/pallets/eth2-light-client/src/tests.rs
@@ -44,6 +44,18 @@ pub fn get_test_context(
 }
 
 mod generic_tests {
+	use super::*;
+	use crate::{
+		mock::new_test_ext,
+		tests::{get_test_context, GOERLI_CHAIN},
+		Error, Paused,
+	};
+	use bitvec::{bitarr, order::Lsb0};
+	use consensus::{EPOCHS_PER_SYNC_COMMITTEE_PERIOD, SLOTS_PER_EPOCH};
+	use eth_types::{H256, U256};
+	use frame_support::assert_err;
+	use hex::FromHex;
+	use tree_hash::TreeHash;
 
 	#[test]
 	pub fn test_header_root() {
@@ -477,6 +489,12 @@ mod generic_tests {
 }
 
 mod mainnet_tests {
+	use super::*;
+	use crate::{
+		tests::{new_test_ext, ALICE, MAINNET_CHAIN},
+		Error,
+	};
+	use frame_support::assert_err;
 
 	#[test]
 	pub fn test_panic_on_init_in_trustless_mode_without_bls_on_mainnet() {

--- a/pallets/light-proposals/Cargo.toml
+++ b/pallets/light-proposals/Cargo.toml
@@ -16,29 +16,29 @@ tree-hash = { package = "webb-tree-hash", path = "../../crates/tree-hash", defau
 tree-hash-derive = { package = "webb-tree-hash-derive", path = "../../crates/tree-hash-derive", default-features = false }
 consensus = { package = "webb-consensus-types", path = "../../crates/consensus-types", default-features = false }
 
-frame-support = { workspace = true }
-frame-system = { workspace = true }
-pallet-balances = { workspace = true }
-sp-runtime = { workspace = true }
-sp-std = { workspace = true }
-sp-core = { workspace = true }
+frame-support = { workspace = true, default-features = false  }
+frame-system = { workspace = true, default-features = false  }
+pallet-balances = { workspace = true, default-features = false  }
+sp-runtime = { workspace = true, default-features = false  }
+sp-std = { workspace = true, default-features = false  }
+sp-core = { workspace = true, default-features = false  }
 
-log = { workspace = true }
-serde = { workspace = true, optional = true }
+log = { workspace = true, default-features = false  }
+serde = { workspace = true, optional = true, default-features = false  }
 codec = { package = "parity-scale-codec",workspace = true, features = ["derive", "max-encoded-len"] }
-scale-info = { workspace = true }
-webb-proposals = { workspace = true, features = ["scale", "evm", "substrate"] }
-ethereum-types =  { workspace = true }
+scale-info = { workspace = true, default-features = false  }
+webb-proposals = { workspace = true, default-features = false, features = ["scale", "evm", "substrate"] }
+ethereum-types =  { workspace = true, default-features = false  }
 derive_more =  { workspace = true }
-rlp =  { workspace = true }
-rlp-derive =  { workspace = true }
-tiny-keccak = { workspace = true }
+rlp =  { workspace = true, default-features = false  }
+rlp-derive =  { workspace = true, default-features = false  }
+tiny-keccak = { workspace = true, default-features = false  }
 bitvec = { workspace = true, features = ["atomic", "alloc"] }
 hex = { workspace = true }
 webb-light-client-primitives = { workspace = true }
 dkg-runtime-primitives = { git = "https://github.com/webb-tools/dkg-substrate.git", branch = "master", default-features = false }
 pallet-bridge-registry = { git = "https://github.com/webb-tools/dkg-substrate.git", branch = "master", default-features = false }
-webb = { workspace = true }
+webb = { workspace = true, default-features = false }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/pallets/light-proposals/Cargo.toml
+++ b/pallets/light-proposals/Cargo.toml
@@ -25,7 +25,7 @@ sp-core = { workspace = true, default-features = false  }
 
 log = { workspace = true, default-features = false  }
 serde = { workspace = true, optional = true, default-features = false  }
-codec = { package = "parity-scale-codec",workspace = true, features = ["derive", "max-encoded-len"] }
+codec = { workspace = true, features = ["derive", "max-encoded-len"] }
 scale-info = { workspace = true, default-features = false  }
 webb-proposals = { workspace = true, default-features = false, features = ["evm", "substrate"] }
 ethereum-types =  { workspace = true, default-features = false  }

--- a/pallets/light-proposals/Cargo.toml
+++ b/pallets/light-proposals/Cargo.toml
@@ -36,8 +36,8 @@ tiny-keccak = { workspace = true }
 bitvec = { workspace = true, features = ["atomic", "alloc"] }
 hex = { workspace = true }
 webb-light-client-primitives = { workspace = true }
-dkg-runtime-primitives = { workspace = true }
-pallet-bridge-registry = { workspace = true }
+dkg-runtime-primitives = { git = "https://github.com/webb-tools/dkg-substrate.git", branch = "master", default-features = false }
+pallet-bridge-registry = { git = "https://github.com/webb-tools/dkg-substrate.git", branch = "master", default-features = false }
 webb = { workspace = true }
 
 [dev-dependencies]
@@ -46,7 +46,7 @@ lazy_static = { workspace = true }
 serde_json = { workspace = true }
 eth2-pallet-init = { package = "webb-eth2-pallet-init", path = "../../crates/eth2-pallet-init" }
 async-trait = { workspace = true }
-pallet-eth2-light-client = { path = "../eth2-light-client", features = ["testing"] }
+pallet-eth2-light-client = { workspace = true, features = ["testing"] }
 
 [features]
 default = ["std"]

--- a/pallets/light-proposals/Cargo.toml
+++ b/pallets/light-proposals/Cargo.toml
@@ -27,7 +27,7 @@ log = { workspace = true, default-features = false  }
 serde = { workspace = true, optional = true, default-features = false  }
 codec = { package = "parity-scale-codec",workspace = true, features = ["derive", "max-encoded-len"] }
 scale-info = { workspace = true, default-features = false  }
-webb-proposals = { workspace = true, default-features = false, features = ["scale", "evm", "substrate"] }
+webb-proposals = { workspace = true, default-features = false, features = ["evm", "substrate"] }
 ethereum-types =  { workspace = true, default-features = false  }
 derive_more =  { workspace = true }
 rlp =  { workspace = true, default-features = false  }

--- a/pallets/light-proposals/src/lib.rs
+++ b/pallets/light-proposals/src/lib.rs
@@ -245,7 +245,7 @@ impl<T: Config> Pallet<T> {
 
 		let unsigned_anchor_update_proposal: Proposal<T::MaxProposalLength> = Proposal::Unsigned {
 			kind: ProposalKind::AnchorUpdate,
-			data: webb_proposals::to_vec(proposal).try_into().unwrap(),
+			data: proposal.encode(),
 		};
 
 		// submit the proposal

--- a/pallets/light-verifier/Cargo.toml
+++ b/pallets/light-verifier/Cargo.toml
@@ -19,6 +19,7 @@ consensus = { package = "webb-consensus-types", path = "../../crates/consensus-t
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 pallet-balances = { workspace = true }
+sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 sp-core = { workspace = true }
@@ -62,6 +63,7 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"pallet-balances/std",
+	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",
 	"sp-core/std",

--- a/pallets/light-verifier/Cargo.toml
+++ b/pallets/light-verifier/Cargo.toml
@@ -26,7 +26,7 @@ sp-core = { workspace = true }
 
 log = { workspace = true }
 serde = { workspace = true, optional = true }
-codec = { package = "parity-scale-codec",workspace = true, features = ["derive", "max-encoded-len"] }
+codec = { workspace = true, features = ["derive", "max-encoded-len"] }
 scale-info = { workspace = true }
 webb-proposals = { workspace = true, features = ["evm", "substrate"] }
 ethereum-types =  { workspace = true }

--- a/pallets/light-verifier/Cargo.toml
+++ b/pallets/light-verifier/Cargo.toml
@@ -28,7 +28,7 @@ log = { workspace = true }
 serde = { workspace = true, optional = true }
 codec = { package = "parity-scale-codec",workspace = true, features = ["derive", "max-encoded-len"] }
 scale-info = { workspace = true }
-webb-proposals = { workspace = true, features = ["scale", "evm", "substrate"] }
+webb-proposals = { workspace = true, features = ["evm", "substrate"] }
 ethereum-types =  { workspace = true }
 ethereum = { version = "0.14", default-features = false, features = ["with-codec"] }
 derive_more =  { workspace = true }

--- a/pallets/light-verifier/Cargo.toml
+++ b/pallets/light-verifier/Cargo.toml
@@ -37,8 +37,7 @@ tiny-keccak = { workspace = true }
 bitvec = { workspace = true, features = ["atomic", "alloc"] }
 hex = { workspace = true }
 webb-light-client-primitives = { workspace = true }
-dkg-runtime-primitives = { workspace = true }
-pallet-bridge-registry = { workspace = true }
+dkg-runtime-primitives = { git = "https://github.com/webb-tools/dkg-substrate.git", branch = "master", default-features = false }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -68,7 +67,6 @@ std = [
 	"sp-core/std",
 	"hex/std",
 	"dkg-runtime-primitives/std",
-	"pallet-bridge-registry/std",
 	"pallet-eth2-light-client/std",
 
 	# Local dependencies

--- a/pallets/light-verifier/src/lib.rs
+++ b/pallets/light-verifier/src/lib.rs
@@ -120,7 +120,7 @@ impl<T: Config> ProofVerifier for Pallet<T> {
 		let storage_hash = header.calculate_hash();
 
 		TrieProver::verify_trie_proof(storage_hash.into(), key, proof)
-			.map_err(|_| Error::<T>::CannotVerifyStorageProof);
+			.map_err(|_| Error::<T>::CannotVerifyStorageProof)?;
 
 		Ok(true)
 	}

--- a/pallets/light-verifier/src/mock.rs
+++ b/pallets/light-verifier/src/mock.rs
@@ -4,9 +4,9 @@ use crate as pallet_light_verifier;
 use codec::{Decode, Encode};
 use consensus::network_config::{Network, NetworkConfig};
 
-use dkg_runtime_primitives::TypedChainId;
 use frame_support::{parameter_types, sp_io, PalletId};
 use frame_system as system;
+use webb_proposals::TypedChainId;
 
 use sp_core::H256;
 use sp_runtime::{

--- a/pallets/light-verifier/src/mock.rs
+++ b/pallets/light-verifier/src/mock.rs
@@ -4,7 +4,7 @@ use crate as pallet_light_verifier;
 use codec::{Decode, Encode};
 use consensus::network_config::{Network, NetworkConfig};
 
-use frame_support::{parameter_types, sp_io, PalletId};
+use frame_support::{parameter_types, PalletId};
 use frame_system as system;
 use webb_proposals::TypedChainId;
 

--- a/pallets/light-verifier/src/tests.rs
+++ b/pallets/light-verifier/src/tests.rs
@@ -6,8 +6,8 @@ use webb_proposals::TypedChainId;
 use frame_support::assert_ok;
 
 use pallet_eth2_light_client::tests::{get_test_context, submit_and_check_execution_headers};
+use sp_core::H256;
 use sp_runtime::AccountId32;
-
 use webb_proposals::{self};
 
 pub const GOERLI_CHAIN: TypedChainId = TypedChainId::Evm(5);

--- a/pallets/light-verifier/src/tests.rs
+++ b/pallets/light-verifier/src/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate as pallet_light_verifier;
 use crate::mock::{Test, *};
-use dkg_runtime_primitives::{TypedChainId, H256};
+use webb_proposals::TypedChainId;
 
 use frame_support::assert_ok;
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -14,7 +14,7 @@ webb-proposals = { workspace = true, features = ["scale", "evm", "substrate"] }
 ethereum-types =  { workspace = true }
 log = { workspace = true }
 serde = { workspace = true, optional = true }
-codec = { package = "parity-scale-codec",workspace = true, features = ["derive", "max-encoded-len"] }
+codec = { package = "parity-scale-codec", workspace = true, features = ["derive", "max-encoded-len"] }
 scale-info = { workspace = true }
 
 [features]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -14,7 +14,7 @@ webb-proposals = { workspace = true }
 ethereum-types =  { workspace = true }
 log = { workspace = true }
 serde = { workspace = true, optional = true }
-codec = { package = "parity-scale-codec", workspace = true, features = ["derive", "max-encoded-len"] }
+codec = { workspace = true, features = ["derive", "max-encoded-len"] }
 scale-info = { workspace = true }
 
 [features]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-
 eth-types = { path = "../crates/eth-types", default-features = false, features = ["eth2", "arbitrary"] }
 frame-support = { workspace = true }
+sp-std = { workspace = true }
 webb-proposals = { workspace = true, features = ["scale", "evm", "substrate"] }
 ethereum-types =  { workspace = true }
 log = { workspace = true }
@@ -20,6 +20,9 @@ scale-info = { workspace = true }
 [features]
 default = ["std"]
 std = [
+	"sp-std/std",
+	"codec/std",
+	"scale-info/std",
 	"webb-proposals/std",
 	"ethereum-types/std",
 	"frame-support/std",

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-eth-types = { path = "../crates/eth-types", default-features = false, features = ["eth2", "arbitrary"] }
+eth-types = { path = "../crates/eth-types", default-features = false, features = ["eth2"] }
 frame-support = { workspace = true }
 sp-std = { workspace = true }
-webb-proposals = { workspace = true, features = ["scale", "evm", "substrate"] }
+webb-proposals = { workspace = true }
 ethereum-types =  { workspace = true }
 log = { workspace = true }
 serde = { workspace = true, optional = true }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -3,6 +3,7 @@
 
 use eth_types::BlockHeader;
 use frame_support::pallet_prelude::DispatchError;
+use sp_std::vec::Vec;
 use webb_proposals::TypedChainId;
 pub mod traits;
 pub mod types;

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -2,8 +2,9 @@
 use serde::{Deserialize, Serialize};
 
 use codec::{Decode, Encode};
-use webb_proposals::ResourceId;
 use scale_info::TypeInfo;
+use sp_std::vec::Vec;
+use webb_proposals::ResourceId;
 
 /// Represents a light proposal input.
 ///

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -63,10 +63,7 @@ pallet-eth2-light-client = { path = "../pallets/eth2-light-client", default-feat
 pallet-eth2-light-client-runtime-api = { path = "../pallets/eth2-light-client/runtime-api", default-features = false }
 
 # DKG Substrate Dependencies
-dkg-runtime-primitives = { workspace = true }
-pallet-dkg-metadata = { workspace = true }
-pallet-dkg-proposal-handler = { workspace = true }
-pallet-dkg-proposals = { workspace = true }
+dkg-runtime-primitives = { git = "https://github.com/webb-tools/dkg-substrate.git", branch = "master", default-features = false }
 
 [build-dependencies]
 substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/paritytech/substrate.git", optional = true , branch = "polkadot-v1.0.0" }
@@ -121,9 +118,6 @@ std = [
 
     # DKG pallets
     "dkg-runtime-primitives/std",
-    "pallet-dkg-metadata/std",
-    "pallet-dkg-proposal-handler/std",
-    "pallet-dkg-proposals/std",
 ]
 runtime-benchmarks = [
     "frame-benchmarking/runtime-benchmarks",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/substrate-developer-hub/substrate-node-template
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", workspace = true, features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 scale-info = { workspace = true }
 log = { workspace = true }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -66,7 +66,7 @@ pallet-eth2-light-client-runtime-api = { path = "../pallets/eth2-light-client/ru
 dkg-runtime-primitives = { git = "https://github.com/webb-tools/dkg-substrate.git", branch = "master", default-features = false }
 
 [build-dependencies]
-substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/paritytech/substrate.git", optional = true , branch = "polkadot-v1.0.0" }
+substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/paritytech/polkadot-sdk", optional = true , branch = "release-polkadot-v1.1.0" }
 
 [features]
 default = ["std"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -62,8 +62,6 @@ frame-system-benchmarking = { workspace = true, optional = true }
 pallet-eth2-light-client = { path = "../pallets/eth2-light-client", default-features = false }
 pallet-eth2-light-client-runtime-api = { path = "../pallets/eth2-light-client/runtime-api", default-features = false }
 
-# DKG Substrate Dependencies
-dkg-runtime-primitives = { git = "https://github.com/webb-tools/dkg-substrate.git", branch = "master", default-features = false }
 
 [build-dependencies]
 substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/paritytech/polkadot-sdk", optional = true , branch = "release-polkadot-v1.1.0" }
@@ -112,12 +110,9 @@ std = [
     "sp-version/std",
     "substrate-wasm-builder",
 
-    # Local pallets
-    "pallet-eth2-light-client/std",
-    "pallet-eth2-light-client-runtime-api/std",
-
-    # DKG pallets
-    "dkg-runtime-primitives/std",
+    # # Local pallets
+    # "pallet-eth2-light-client/std",
+    # "pallet-eth2-light-client-runtime-api/std",
 ]
 runtime-benchmarks = [
     "frame-benchmarking/runtime-benchmarks",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -62,7 +62,6 @@ frame-system-benchmarking = { workspace = true, optional = true }
 pallet-eth2-light-client = { path = "../pallets/eth2-light-client", default-features = false }
 pallet-eth2-light-client-runtime-api = { path = "../pallets/eth2-light-client/runtime-api", default-features = false }
 
-
 [build-dependencies]
 substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/paritytech/polkadot-sdk", optional = true , branch = "release-polkadot-v1.1.0" }
 
@@ -109,10 +108,9 @@ std = [
     "sp-transaction-pool/std",
     "sp-version/std",
     "substrate-wasm-builder",
-
     # # Local pallets
-    # "pallet-eth2-light-client/std",
-    # "pallet-eth2-light-client-runtime-api/std",
+    "pallet-eth2-light-client/std",
+    "pallet-eth2-light-client-runtime-api/std",
 ]
 runtime-benchmarks = [
     "frame-benchmarking/runtime-benchmarks",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -572,90 +572,6 @@ impl pallet_utility::Config for Runtime {
 }
 
 parameter_types! {
-	pub const DecayPercentage: Percent = Percent::from_percent(50);
-	pub const UnsignedPriority: u64 = 1 << 20;
-	pub const UnsignedInterval: BlockNumber = 1;
-	pub const SessionPeriod : BlockNumber = Period::get();
-	#[derive(Default, Clone, Encode, Decode, Debug, Eq, PartialEq, scale_info::TypeInfo, Ord, PartialOrd, codec::MaxEncodedLen)]
-	pub const VoteLength: u32 = 64;
-}
-
-impl pallet_dkg_metadata::Config for Runtime {
-	type DKGId = DKGId;
-	type RuntimeEvent = RuntimeEvent;
-	type OnAuthoritySetChangeHandler = DKGProposals;
-	type OnDKGPublicKeyChangeHandler = ();
-	type OffChainAuthId = dkg_runtime_primitives::offchain::crypto::OffchainAuthId;
-	type NextSessionRotation = pallet_dkg_metadata::DKGPeriodicSessions<Period, Offset, Runtime>;
-	type KeygenJailSentence = Period;
-	type SigningJailSentence = Period;
-	type DecayPercentage = DecayPercentage;
-	type Reputation = Reputation;
-	type ForceOrigin = EnsureRoot<AccountId>;
-	type UnsignedPriority = UnsignedPriority;
-	type SessionPeriod = SessionPeriod;
-	type UnsignedInterval = UnsignedInterval;
-	type AuthorityIdOf = pallet_dkg_metadata::AuthorityIdOf<Self>;
-	type ProposalHandler = DKGProposalHandler;
-	type MaxKeyLength = MaxKeyLength;
-	type MaxSignatureLength = MaxSignatureLength;
-	type MaxReporters = MaxReporters;
-	type MaxAuthorities = MaxAuthorities;
-	type VoteLength = VoteLength;
-	type MaxProposalLength = MaxProposalLength;
-	type WeightInfo = pallet_dkg_metadata::weights::WebbWeight<Runtime>;
-}
-
-parameter_types! {
-	pub const ChainIdentifier: TypedChainId = TypedChainId::Substrate(1081);
-	pub const ProposalLifetime: BlockNumber = HOURS / 5;
-	pub const DKGAccountId: PalletId = PalletId(*b"dw/dkgac");
-	pub const RefreshDelay: Permill = Permill::from_percent(90);
-	pub const TimeToRestart: BlockNumber = 3;
-	pub const UnsignedProposalExpiry: BlockNumber = 10;
-}
-
-impl pallet_dkg_proposal_handler::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type ForceOrigin = EnsureRoot<AccountId>;
-	type OffChainAuthId = dkg_runtime_primitives::offchain::crypto::OffchainAuthId;
-	type UnsignedProposalExpiry = UnsignedProposalExpiry;
-	type SignedProposalHandler = DKG;
-	type MaxProposalsPerBatch = dkg_runtime_primitives::CustomU32Getter<10>;
-	type BatchId = u32;
-	type ValidatorSet = Historical;
-	type ReportOffences = ();
-	type WeightInfo = pallet_dkg_proposal_handler::weights::WebbWeight<Runtime>;
-}
-
-parameter_types! {
-	#[derive(Clone, Encode, Decode, Debug, Eq, PartialEq, scale_info::TypeInfo, Ord, PartialOrd)]
-	pub const MaxVotes : u32 = 100;
-	#[derive(Clone, Encode, Decode, Debug, Eq, PartialEq, scale_info::TypeInfo, Ord, PartialOrd)]
-	pub const MaxResources : u32 = 1000;
-	#[derive(Clone, Encode, Decode, Debug, Eq, PartialEq, scale_info::TypeInfo, Ord, PartialOrd)]
-	pub const MaxProposers : u32 = 1000;
-}
-
-impl pallet_dkg_proposals::Config for Runtime {
-	type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
-	type DKGAuthorityToMerkleLeaf = pallet_dkg_proposals::DKGEcdsaToEthereumAddress;
-	type DKGId = DKGId;
-	type ChainIdentifier = ChainIdentifier;
-	type RuntimeEvent = RuntimeEvent;
-	type NextSessionRotation = pallet_dkg_metadata::DKGPeriodicSessions<Period, Offset, Runtime>;
-	type MaxProposalLength = MaxProposalLength;
-	type ProposalLifetime = ProposalLifetime;
-	type ProposalHandler = DKGProposalHandler;
-	type Period = Period;
-	type MaxVotes = MaxVotes;
-	type MaxResources = MaxResources;
-	type MaxProposers = MaxProposers;
-	type VotingKeySize = MaxKeyLength;
-	type WeightInfo = pallet_dkg_proposals::WebbWeight<Runtime>;
-}
-
-parameter_types! {
 	pub const StoragePricePerByte: u128 = 100;
 	pub const Eth2ClientPalletId: PalletId = PalletId(*b"py/eth2c");
 }
@@ -739,10 +655,6 @@ construct_runtime!(
 		Staking: pallet_staking,
 		Session: pallet_session,
 		Historical: pallet_session_historical,
-		// DKG / offchain worker
-		DKG: pallet_dkg_metadata,
-		DKGProposals: pallet_dkg_proposals,
-		DKGProposalHandler: pallet_dkg_proposal_handler,
 		// Eth2 light client
 		Eth2Client: pallet_eth2_light_client,
 	}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -574,10 +574,10 @@ impl pallet_utility::Config for Runtime {
 parameter_types! {
 	pub const DecayPercentage: Percent = Percent::from_percent(50);
 	pub const UnsignedPriority: u64 = 1 << 20;
-	 pub const UnsignedInterval: BlockNumber = 1;
-	 pub const SessionPeriod : BlockNumber = Period::get();
-	 #[derive(Default, Clone, Encode, Decode, Debug, Eq, PartialEq, scale_info::TypeInfo, Ord, PartialOrd, codec::MaxEncodedLen)]
-	 pub const VoteLength: u32 = 64;
+	pub const UnsignedInterval: BlockNumber = 1;
+	pub const SessionPeriod : BlockNumber = Period::get();
+	#[derive(Default, Clone, Encode, Decode, Debug, Eq, PartialEq, scale_info::TypeInfo, Ord, PartialOrd, codec::MaxEncodedLen)]
+	pub const VoteLength: u32 = 64;
 }
 
 impl pallet_dkg_metadata::Config for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -35,7 +35,7 @@ use sp_runtime::{
 		SaturatedConversion, StaticLookup, Verify,
 	},
 	transaction_validity::{TransactionPriority, TransactionSource, TransactionValidity},
-	ApplyExtrinsicResult, MultiSignature, Percent,
+	ApplyExtrinsicResult, MultiSignature,
 };
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
@@ -325,9 +325,9 @@ parameter_types! {
 	pub const StakingUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
 
 	// signed config
-	pub const SignedRewardBase: Balance = 1 * DOLLARS;
-	pub const SignedDepositBase: Balance = 1 * DOLLARS;
-	pub const SignedDepositByte: Balance = 1 * CENTS;
+	pub const SignedRewardBase: Balance = DOLLARS;
+	pub const SignedDepositBase: Balance = DOLLARS;
+	pub const SignedDepositByte: Balance = CENTS;
 
 	pub BetterUnsignedThreshold: Perbill = Perbill::from_rational(1u32, 10_000);
 
@@ -497,7 +497,7 @@ impl pallet_aura::Config for Runtime {
 }
 
 parameter_types! {
-	pub const IndexDeposit: Balance = 1 * DOLLARS;
+	pub const IndexDeposit: Balance = DOLLARS;
 }
 
 impl pallet_indices::Config for Runtime {


### PR DESCRIPTION
## Summary of changes
- Remove dkg substrate from runtime and as much of it as needed for now. (we need just base light client and verifier pallet, not anchor submitter, which we can build as a precompile)
- Update to polkadot-v1.1.0

### Issues
no_std leak somewhere, sys errors
```
  error[E0583]: file not found for module `sys`
    --> /Users/drew/.cargo/registry/src/index.crates.io-6f17d22bba15001f/errno-0.3.8/src/lib.rs:26:1
     |
  26 | mod sys;
     | ^^^^^^^^
     |
     = help: to create the module `sys`, create file "/Users/drew/.cargo/registry/src/index.crates.io-6f17d22bba15001f/errno-0.3.8/src/sys.rs" or "/Users/drew/.cargo/registry/src/index.crates.io-6f17d22bba15001f/errno-0.3.8/src/sys/mod.rs"

  error[E0425]: cannot find function `with_description` in module `sys`
    --> /Users/drew/.cargo/registry/src/index.crates.io-6f17d22bba15001f/errno-0.3.8/src/lib.rs:47:14
     |
  47 |         sys::with_description(*self, |desc| {
     |              ^^^^^^^^^^^^^^^^ not found in `sys`

  error[E0425]: cannot find function `with_description` in module `sys`
    --> /Users/drew/.cargo/registry/src/index.crates.io-6f17d22bba15001f/errno-0.3.8/src/lib.rs:58:14
     |
  58 |         sys::with_description(*self, |desc| match desc {
     |              ^^^^^^^^^^^^^^^^ not found in `sys`

  error[E0425]: cannot find value `STRERROR_NAME` in module `sys`
    --> /Users/drew/.cargo/registry/src/index.crates.io-6f17d22bba15001f/errno-0.3.8/src/lib.rs:64:22
     |
  64 |                 sys::STRERROR_NAME,
     |                      ^^^^^^^^^^^^^ not found in `sys`

  error[E0425]: cannot find function `errno` in module `sys`
    --> /Users/drew/.cargo/registry/src/index.crates.io-6f17d22bba15001f/errno-0.3.8/src/lib.rs:95:10
     |
  95 |     sys::errno()
     |          ^^^^^ not found in `sys`

  error[E0425]: cannot find function `set_errno` in module `sys`
     --> /Users/drew/.cargo/registry/src/index.crates.io-6f17d22bba15001f/errno-0.3.8/src/lib.rs:100:10
      |
  100 |     sys::set_errno(err)
      |          ^^^^^^^^^ not found in `sys`

  Some errors have detailed explanations: E0425, E0583.
  For more information about an error, try `rustc --explain E0425`.
  error: could not compile `errno` (lib) due to 6 previous errors
  warning: build failed, waiting for other jobs to finish...
  The following warnings were emitted during compilation:

  warning: src/helpers.c:1:10: fatal error: 'setjmp.h' file not found
  warning: #include <setjmp.h>
  warning:          ^~~~~~~~~~
  warning: 1 error generated.

  error: failed to run custom build command for `wasmtime-runtime v8.0.1`

  Caused by:
    process didn't exit successfully: `/Users/drew/webb/pallet-eth2-light-client/target/debug/wbuild/node-template-runtime/target/release/build/wasmtime-runtime-18480c83287cb3a1/build-script-build` (exit status: 1)
    --- stdout
    cargo:rerun-if-changed=src/helpers.c
    TARGET = Some("wasm32-unknown-unknown")
    OPT_LEVEL = Some("3")
    HOST = Some("aarch64-apple-darwin")
    cargo:rerun-if-env-changed=CC_wasm32-unknown-unknown
    CC_wasm32-unknown-unknown = None
    cargo:rerun-if-env-changed=CC_wasm32_unknown_unknown
    CC_wasm32_unknown_unknown = None
    cargo:rerun-if-env-changed=TARGET_CC
    TARGET_CC = None
    cargo:rerun-if-env-changed=CC
    CC = None
    cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
    CRATE_CC_NO_DEFAULTS = None
    DEBUG = Some("false")
    cargo:rerun-if-env-changed=CFLAGS_wasm32-unknown-unknown
    CFLAGS_wasm32-unknown-unknown = None
    cargo:rerun-if-env-changed=CFLAGS_wasm32_unknown_unknown
    CFLAGS_wasm32_unknown_unknown = None
    cargo:rerun-if-env-changed=TARGET_CFLAGS
    TARGET_CFLAGS = None
    cargo:rerun-if-env-changed=CFLAGS
    CFLAGS = None
    running: "clang" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "--target=wasm32-unknown-unknown" "-Wall" "-Wextra" "-DCFG_TARGET_OS_unknown" "-DCFG_TARGET_ARCH_wasm32" "-o" "/Users/drew/webb/pallet-eth2-light-client/target/debug/wbuild/node-template-runtime/target/wasm32-unknown-unknown/release/build/wasmtime-runtime-5c9d82fa6476ee21/out/src/helpers.o" "-c" "src/helpers.c"
    cargo:warning=src/helpers.c:1:10: fatal error: 'setjmp.h' file not found

    cargo:warning=#include <setjmp.h>

    cargo:warning=         ^~~~~~~~~~

    cargo:warning=1 error generated.

    exit status: 1

    --- stderr


    error occurred: Command "clang" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "--target=wasm32-unknown-unknown" "-Wall" "-Wextra" "-DCFG_TARGET_OS_unknown" "-DCFG_TARGET_ARCH_wasm32" "-o" "/Users/drew/webb/pallet-eth2-light-client/target/debug/wbuild/node-template-runtime/target/wasm32-unknown-unknown/release/build/wasmtime-runtime-5c9d82fa6476ee21/out/src/helpers.o" "-c" "src/helpers.c" with args "clang" did not execute successfully (status code exit status: 1).
```

### Reference issue to close (if applicable)
- Closes 

-----
### Code Checklist 

- [ ] Tested
- [ ] Documented
